### PR TITLE
fix: remove font preloads

### DIFF
--- a/config/head.js
+++ b/config/head.js
@@ -9,27 +9,6 @@ export default {
                 type: 'image/x-icon',
             },
             {
-                as: 'font',
-                crossorigin: 'anonymous',
-                href: '/fonts/NotoSerif-ExtraLight.woff2',
-                rel: 'preload',
-                type: 'font/woff2',
-            },
-            {
-                as: 'font',
-                crossorigin: 'anonymous',
-                href: '/fonts/NotoSerif-LightItalic.woff2',
-                rel: 'preload',
-                type: 'font/woff2',
-            },
-            {
-                as: 'font',
-                crossorigin: 'anonymous',
-                href: '/fonts/NotoSerif.woff2',
-                rel: 'preload',
-                type: 'font/woff2',
-            },
-            {
                 href: 'https://daan.vosdewael.dev/',
                 rel: 'canonical',
             },


### PR DESCRIPTION
Because Netlify hosts the fonts on Cloudfront, the `href` for the preload is not matching.
So two requests will be fired for the font files.